### PR TITLE
Added/improved comments explaining the why and how of the `ios-bridge.html` file

### DIFF
--- a/ios/Party Line/API/Client.swift
+++ b/ios/Party Line/API/Client.swift
@@ -91,6 +91,8 @@ final class Client: NSObject, ObservableObject {
 
     /// The URL of the page that.
     private static var pageURL: URL {
+        // The source file behind this URL can be found at `react/public/ios-bridge.html`
+        // along with an explanation of why it needs to be hosted externally for now:
         URL(string: "https://audio-only-server.netlify.app/static/bridge.html")!
     }
 

--- a/react/public/ios-bridge.html
+++ b/react/public/ios-bridge.html
@@ -7,9 +7,11 @@
 </head>
 
 <!--
-This file would be bundled with your iOS app and loaded locally.
+PSA: This file actually belongs to the iOS demo and is entirely unrelated to the react demo.
+We simply have it piggy back on the react deployment as it needs to be hosted (for now; see below).
 
-However!
+In a perfect world this file would simply be bundled with your iOS app and loaded directly from there.
+Alas the world isn't perfect — gestures broadly at everything — and this demo isn't either.
 
 Up until iOS 14.3 `WKWebView` did not support accessing `navigator.mediaDevices.getUserMedia`, a crucial ingredient to WebRTC.
 
@@ -28,6 +30,8 @@ Since loading a local HTML file via `URL(fileURL: …)` into a `WKWebView` resul
 this demo is affected by aforementioned bug, forcing us to load the file from a HTTPS server instead.
 
 Once the fix made it into the next version of iOS the remote-server workaround will not be necessary any more.
+
+To see where and how this file is used by the iOS demo take a look at `ios/Party Line/API/Client.swift`, specifically `Client.pageURL`.
 
 Related tickets:
 - https://openradar.appspot.com/48813943 (rdar://48813943)


### PR DESCRIPTION
In its current state from the perspective of somebody spelunking in the iOS demo project the `https://…/bridge.html` URL leads to an opaque blackbox behind a server, while from the perspective of spelunking in the React demo the `ios-bridge.html` feels out of place and confusing to say the least.

A comment on both ends attempts to mitigate the situation.