### PR TITLE
made _ optional as name/role separator

### DIFF
--- a/ios/Party Line/API/Participant.swift
+++ b/ios/Party Line/API/Participant.swift
@@ -159,7 +159,7 @@ private struct ParsedUsername: RawRepresentable {
     }
 
     init?(rawValue: String) {
-        let pattern = "^(?:(✋) )?(.+)(?:_(MOD|SPK|LST))$"
+        let pattern = "^(?:(✋) )?(.+?)(?:_?(MOD|SPK|LST))$"
 
         let regex = try! NSRegularExpression(
           pattern: pattern,


### PR DESCRIPTION
Fix for Android participants not showing up on iOS.

Android doesn't have an underscore as a separator between the user_name and the role. The iOS JSON parsing logic errors out because it's looking for the underscore. So no `participant-` events from Android are processed.