### PR TITLE
Fix iOS json decoding

### DIFF
--- a/ios/Party Line/API/Client.swift
+++ b/ios/Party Line/API/Client.swift
@@ -541,7 +541,7 @@ extension Client: WKScriptMessageHandler {
         }
 
         do {
-            let decoder = JSONDecoder.daily
+            let decoder = JSONDecoder.daily()
             let message = try decoder.decode(EventMessage.self, from: data)
 
             print("Event:", message.action, "=>" , String(reflecting: message.event))
@@ -571,7 +571,8 @@ extension Client: WKScriptMessageHandler {
         }
 
         do {
-            let message = try JSONDecoder().decode(ConsoleMessage.self, from: data)
+            let decoder = JSONDecoder.daily()
+            let message = try decoder.decode(ConsoleMessage.self, from: data)
             switch message.level {
             case .log:
                 logger.log("WebView Console: \(message.content)")
@@ -601,7 +602,8 @@ extension Client: WKScriptMessageHandler {
         }
 
         do {
-            let message = try JSONDecoder().decode(ErrorMessage.self, from: data)
+            let decoder = JSONDecoder.daily()
+            let message = try decoder.decode(ErrorMessage.self, from: data)
             logger.error("WebView Error: \(message.content)")
         } catch let error {
             logger.error("Error decoding error message: \(error.localizedDescription)")

--- a/ios/Party Line/API/Client.swift
+++ b/ios/Party Line/API/Client.swift
@@ -553,7 +553,9 @@ extension Client: WKScriptMessageHandler {
                 logger.warning("Event content: \(String(describing: message.content as Any))")
             }
         } catch let error {
-            logger.error("Error decoding event message: \(error.localizedDescription)")
+            let messageString = String(data: data, encoding: .utf8)!
+            let errorMessage = String(reflecting: error)
+            logger.error("Error decoding event message: \(messageString) (Error: \(errorMessage))")
             return
         }
     }
@@ -584,7 +586,9 @@ extension Client: WKScriptMessageHandler {
                 logger.error("WebView Console: \(message.content)")
             }
         } catch let error {
-            logger.error("Error decoding console message: \(error.localizedDescription)")
+            let messageString = String(data: data, encoding: .utf8)!
+            let errorMessage = String(reflecting: error)
+            logger.error("Error decoding event message: \(messageString) (Error: \(errorMessage))")
             return
         }
     }
@@ -606,7 +610,9 @@ extension Client: WKScriptMessageHandler {
             let message = try decoder.decode(ErrorMessage.self, from: data)
             logger.error("WebView Error: \(message.content)")
         } catch let error {
-            logger.error("Error decoding error message: \(error.localizedDescription)")
+            let messageString = String(data: data, encoding: .utf8)!
+            let errorMessage = String(reflecting: error)
+            logger.error("Error decoding event message: \(messageString) (Error: \(errorMessage))")
             return
         }
     }

--- a/ios/Party Line/API/Participant.swift
+++ b/ios/Party Line/API/Participant.swift
@@ -56,25 +56,29 @@ struct Participant: Decodable {
 
         let rawUsername = try container.decode(String.self, forKey: .username)
 
-        guard let parsedUsername = ParsedUsername(rawValue: rawUsername) else {
-            throw DecodingError.typeMismatch(
-                JSONValue.self,
-                DecodingError.Context(
-                    codingPath: container.codingPath,
-                    debugDescription: "Not a valid username"
-                )
-            )
+        let username: String
+        let role: Role
+        let isHandRaised: Bool
+
+        if let parsedUsername = ParsedUsername(rawValue: rawUsername) {
+            username = parsedUsername.username
+            role = parsedUsername.role
+            isHandRaised = parsedUsername.isHandRaised
+        } else {
+            username = rawUsername
+            role = .listener
+            isHandRaised = false
         }
 
         self.init(
             sessionID: sessionID,
             userID: userID,
-            username: parsedUsername.username,
-            role: parsedUsername.role,
+            username: username,
+            role: role,
             isLocal: isLocal,
             isOwner: isOwner,
             isMicrophoneEnabled: isMicrophoneEnabled,
-            isHandRaised: parsedUsername.isHandRaised
+            isHandRaised: isHandRaised
         )
     }
 

--- a/ios/Party Line/Auxiliaries/JSONValue.swift
+++ b/ios/Party Line/Auxiliaries/JSONValue.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum JSONValue: Decodable {
+    case null
     case bool(Bool)
     case int(Int)
     case double(Double)
@@ -22,6 +23,8 @@ enum JSONValue: Decodable {
             self = .object(value)
         } else if let value = try? container.decode([JSONValue].self) {
             self = .array(value)
+        } else if container.decodeNil() {
+            self = .null
         } else {
             throw DecodingError.typeMismatch(
                 JSONValue.self,
@@ -37,6 +40,8 @@ enum JSONValue: Decodable {
 extension JSONValue: CustomStringConvertible {
     var description: String {
         switch self {
+        case .null:
+            return "null"
         case .bool(let value):
             return value.description
         case .int(let value):

--- a/ios/Party Line/Extensions/JSONDecoder.swift
+++ b/ios/Party Line/Extensions/JSONDecoder.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension JSONDecoder {
-    static var daily: JSONDecoder {
+    static func daily() -> JSONDecoder {
         let decoder = JSONDecoder()
 
         decoder.dateDecodingStrategy = .custom { decoder in


### PR DESCRIPTION
This PR …

- … fixes a bug in the JSON decoding logic on iOS that would fail if a JSON payload contained any `null` values.
- … replaces a hard fail on invalid usernames with a soft fallback to defaults (as the API sometimes returns empty usernames when joining a call, before updating them).